### PR TITLE
Update debug adapter with new configuration

### DIFF
--- a/adapter/build.gradle.kts
+++ b/adapter/build.gradle.kts
@@ -33,6 +33,8 @@ dependencies {
     implementation("org.jetbrains.exposed:exposed-core:0.37.3")
     implementation("org.jetbrains.exposed:exposed-dao:0.37.3")
 
+    implementation(libs.com.google.protobuf.java)
+
 
 	testImplementation("junit:junit:4.12")
 	testImplementation("org.hamcrest:hamcrest-all:1.3")

--- a/adapter/src/main/kotlin/org/javacs/ktda/core/launch/AttachConfiguration.kt
+++ b/adapter/src/main/kotlin/org/javacs/ktda/core/launch/AttachConfiguration.kt
@@ -3,7 +3,7 @@ package org.javacs.ktda.core.launch
 import java.nio.file.Path
 
 class AttachConfiguration(
-	val projectRoot: Path,
+	val workspaceRoot: Path,
 	val hostName: String,
 	val port: Int,
 	val timeout: Int

--- a/adapter/src/main/kotlin/org/javacs/ktda/core/launch/LaunchConfiguration.kt
+++ b/adapter/src/main/kotlin/org/javacs/ktda/core/launch/LaunchConfiguration.kt
@@ -5,6 +5,8 @@ import java.nio.file.Path
 class LaunchConfiguration(
 	val classpath: Set<Path>,
 	val mainClass: String,
-	val projectRoot: Path,
+    val bazelTarget: String,
+    val buildArgs: List<String>,
+	val workspaceRoot: Path,
 	val vmArguments: String = ""
 )

--- a/adapter/src/main/kotlin/org/javacs/ktda/jdi/JDIDebuggee.kt
+++ b/adapter/src/main/kotlin/org/javacs/ktda/jdi/JDIDebuggee.kt
@@ -31,7 +31,7 @@ import java.nio.charset.StandardCharsets
 
 class JDIDebuggee(
 	private val vm: VirtualMachine,
-	private val sourcesRoots: Set<Path>,
+	private val sourceFiles: Set<Path>,
 	private val context: DebugContext
 ) : Debuggee, JDISessionContext {
 	override var threads = emptyList<DebuggeeThread>()
@@ -172,10 +172,9 @@ class JDIDebuggee(
             val sourcePath = location.sourcePath()
             val sourceName = location.sourceName()
 
-            sourcesRoots
+            sourceFiles
                 .asSequence()
                 .map { it.resolve(sourcePath) }
-                .orEmpty()
                 .mapNotNull { findValidKtFilePath(it, sourceName) }
                 .firstOrNull()
                 ?.let { Source(

--- a/adapter/src/test/kotlin/org/javacs/ktda/DebugAdapterTestFixture.kt
+++ b/adapter/src/test/kotlin/org/javacs/ktda/DebugAdapterTestFixture.kt
@@ -51,8 +51,10 @@ abstract class DebugAdapterTestFixture(
     fun launch() {
         println("Launching...")
         debugAdapter.launch(mapOf(
-            "projectRoot" to absoluteWorkspaceRoot.toString(),
+            "workspaceRoot" to absoluteWorkspaceRoot.toString(),
+            "bazelTarget" to "//foo/bar",
             "mainClass" to mainClass,
+            "buildArgs" to listOf<String>(),
             "vmArguments" to vmArguments
         )).join()
         println("Launched")


### PR DESCRIPTION
Support changes from https://github.com/smocherla-brex/bazel-kotlin-vscode-extension/pull/19 here

To solve #12 

- Update adapter to use new configuration that's bazel specific
- Update source roots logic used for source files that's gradle/maven specific, and instead get the transitive closure of source files from the aspect outputs.

There's still work left to `bazel build` the target and then wire it up to the debugger, that should be in a follow-up