### PR TITLE
Run bazel build in debug adapter on launch

### DIFF
--- a/adapter/src/main/kotlin/org/javacs/ktda/KDAMain.kt
+++ b/adapter/src/main/kotlin/org/javacs/ktda/KDAMain.kt
@@ -11,6 +11,7 @@ import org.javacs.ktda.util.LoggingOutputStream
 import org.eclipse.lsp4j.debug.launch.DSPLauncher
 import org.eclipse.lsp4j.debug.services.IDebugProtocolClient
 import org.eclipse.lsp4j.debug.TerminatedEventArguments
+import org.javacs.ktda.build.BazelBuildService
 
 /** Enable logging of raw input JSON messages (if it is enabled in the user's debug configuration). */
 private const val JSON_IN_LOGGING = true
@@ -22,20 +23,20 @@ private const val JSON_OUT_LOGGING_BUFFER_LINES = true
 
 fun main(args: Array<String>) {
 	LOG.connectJULFrontend()
-	
+
 	val launcher: DebugLauncher = JDILauncher()
-	
+
 	// Setup IO streams for JSON communication
-	
+
 	val input = LoggingInputStream(ExitingInputStream(System.`in`), JSON_IN_LOGGING, JSON_IN_LOGGING_BUFFER_LINES)
 	val output = LoggingOutputStream(System.out, JSON_OUT_LOGGING, JSON_OUT_LOGGING_BUFFER_LINES)
-	
+
 	// Create debug adapter and launcher
-	
-	val debugAdapter = KotlinDebugAdapter(launcher)
+
+	val debugAdapter = KotlinDebugAdapter(launcher, BazelBuildService())
 	val threads = Executors.newSingleThreadExecutor { Thread(it, "server") }
 	val serverLauncher = DSPLauncher.createServerLauncher(debugAdapter, input, output, threads) { it }
-	
+
 	debugAdapter.connect(serverLauncher.remoteProxy)
 	serverLauncher.startListening()
 }

--- a/adapter/src/main/kotlin/org/javacs/ktda/jdi/launch/JDILauncher.kt
+++ b/adapter/src/main/kotlin/org/javacs/ktda/jdi/launch/JDILauncher.kt
@@ -1,14 +1,13 @@
 package org.javacs.ktda.jdi.launch
 
 import com.sun.jdi.Bootstrap
-import com.sun.jdi.ReferenceType
 import com.sun.jdi.VirtualMachineManager
 import com.sun.jdi.connect.AttachingConnector
 import com.sun.jdi.connect.Connector
 import com.sun.jdi.connect.LaunchingConnector
 import org.javacs.kt.LOG
-import org.javacs.kt.classpath.PackageSourceMapping
 import org.javacs.kt.proto.LspInfo
+import org.javacs.ktda.build.BuildService
 import org.javacs.ktda.core.DebugContext
 import org.javacs.ktda.core.launch.AttachConfiguration
 import org.javacs.ktda.core.launch.DebugLauncher
@@ -30,7 +29,7 @@ import kotlin.io.path.isRegularFile
 class JDILauncher(
 	private val attachTimeout: Int = 50,
 	private val vmArguments: String? = null,
-	private val modulePaths: String? = null
+	private val modulePaths: String? = null,
 ) : DebugLauncher {
 	private val vmManager: VirtualMachineManager
 		get() = Bootstrap.virtualMachineManager()

--- a/adapter/src/test/kotlin/org/javacs/ktda/DebugAdapterTestFixture.kt
+++ b/adapter/src/test/kotlin/org/javacs/ktda/DebugAdapterTestFixture.kt
@@ -13,6 +13,8 @@ import org.junit.After
 import org.junit.Assert.assertThat
 import org.junit.Before
 import org.hamcrest.Matchers.equalTo
+import org.javacs.ktda.build.BuildService
+import java.util.concurrent.CompletableFuture
 
 abstract class DebugAdapterTestFixture(
     relativeWorkspaceRoot: String,
@@ -22,10 +24,18 @@ abstract class DebugAdapterTestFixture(
     val absoluteWorkspaceRoot: Path = Paths.get(DebugAdapterTestFixture::class.java.getResource("/bazel/WORKSPACE").toURI()).parent.resolve(relativeWorkspaceRoot)
     lateinit var debugAdapter: KotlinDebugAdapter
 
+    class MockBuildService : BuildService {
+        override fun build(workspaceRoot: Path, targets: List<String>, args: List<String>): CompletableFuture<Void> {
+            return CompletableFuture.completedFuture(null)
+        }
+    }
+
     @Before fun startDebugAdapter() {
 
         debugAdapter = JDILauncher()
-            .let(::KotlinDebugAdapter)
+            .let{
+                KotlinDebugAdapter(it, MockBuildService())
+            }
             .also {
                 it.connect(this)
                 val configDone = it.configurationDone(ConfigurationDoneArguments())


### PR DESCRIPTION
- Run bazel build through launch configuration
- this is required before binaries are available and we can find classpath and attach to JDI
- mock build in tests 