### PR TITLE
Handle NPE when location is not found in source jar

### DIFF
--- a/detekt_baseline.xml
+++ b/detekt_baseline.xml
@@ -126,6 +126,7 @@
     <ID>ReturnCount:FindDoc.kt$fun findDoc(declaration: DeclarationDescriptorWithSource): KDocTag?</ID>
     <ID>ReturnCount:FindReferences.kt$private fun possibleReferences(declaration: DeclarationDescriptor, sp: SourcePath): Set&lt;KtFile&gt;</ID>
     <ID>ReturnCount:GoToDefinition.kt$fun processJarEntry(packageSourceMapping: PackageSourceMapping): Location?</ID>
+    <ID>ReturnCount:GoToDefinition.kt$private fun findLocation( workspaceRoot: Path, sourceJar: String, packageName: String, className: String, symbolName: String, compiler: Compiler, tempDir: TemporaryDirectory ): Location?</ID>
     <ID>ReturnCount:Hovers.kt$@OptIn(IDEAPluginsCompatibilityAPI::class) private fun renderTypeOf(element: KtExpression, bindingContext: BindingContext): String?</ID>
     <ID>ReturnCount:Hovers.kt$fun processSourceJar(mapping: PackageSourceMapping): String?</ID>
     <ID>ReturnCount:Hovers.kt$private fun typeHoverAt(file: CompiledFile, cursor: Int): Hover?</ID>

--- a/server/src/main/kotlin/org/javacs/kt/definition/GoToDefinition.kt
+++ b/server/src/main/kotlin/org/javacs/kt/definition/GoToDefinition.kt
@@ -98,7 +98,7 @@ private fun findLocation(
     val range = compiler.findDeclarationRange(
         sourceFileInfo.contents,
         declarationName = symbolName,
-    )
+    ) ?: return null
 
     return when {
         // Need a better way to do this - this is to ensure we try to


### PR DESCRIPTION
When we don't find a symbol in source jars, we delegate to the PSI where we can find most of the symbols in the source tree after compilation, however we're not handling an NPE here which leads to a runtime error and the fallback mechanism never runs.

The LSP APIs are in Java so we couldn't find this at compile time