### PR TITLE
Ignore unknown fields while parsing protojson

### DIFF
--- a/shared/src/main/kotlin/org/javacs/kt/proto/LspInfo.kt
+++ b/shared/src/main/kotlin/org/javacs/kt/proto/LspInfo.kt
@@ -9,7 +9,7 @@ object LspInfo {
     fun fromJson(jsonFile: Path): KotlinLspBazelTargetInfo {
         val targetInfo = KotlinLspBazelTargetInfo.newBuilder()
         val protoJson = jsonFile.toFile().readText()
-        JsonFormat.parser().merge(protoJson, targetInfo)
+        JsonFormat.parser().ignoringUnknownFields().merge(protoJson, targetInfo)
         return targetInfo.build()
     }
 }


### PR DESCRIPTION
This will allow me to add new proto fields without breaking it at runtime here.