### PR TITLE
fix: Pass java source files correctly to the Kotlin compiler

### DIFF
--- a/detekt_baseline.xml
+++ b/detekt_baseline.xml
@@ -23,6 +23,7 @@
     <ID>ForbiddenComment:Compiler.kt$CompilationEnvironment$// TODO: Use ScriptDefinition.FromLegacyTemplate directly if possible</ID>
     <ID>ForbiddenComment:Compiler.kt$Compiler$// TODO: Lock at file-level</ID>
     <ID>ForbiddenComment:CompilerClassPath.kt$CompilerClassPath$// TODO: Fetch class path and build script class path concurrently (and asynchronously)</ID>
+    <ID>ForbiddenComment:CompilerClassPath.kt$CompilerClassPath$// TODO: we walk bazel-out here again to collect the files emitted by the aspect</ID>
     <ID>ForbiddenComment:Completions.kt$// TODO: CRLF?</ID>
     <ID>ForbiddenComment:Completions.kt$// TODO: Deal with alias imports</ID>
     <ID>ForbiddenComment:Completions.kt$// TODO: Visibility checker should be less liberal</ID>
@@ -49,8 +50,6 @@
     <ID>ForbiddenComment:OverrideMembers.kt$// TODO: look into this</ID>
     <ID>ForbiddenComment:OverrideMembers.kt$// TODO: see where this should ideally be placed</ID>
     <ID>ForbiddenComment:PathUtils.kt$// TODO: Better path resolution, especially when dealing with</ID>
-    <ID>ForbiddenComment:PathUtils.kt$// TODO: Implement this using the Kotlin compiler API instead</ID>
-    <ID>ForbiddenComment:PathUtils.kt$// TODO: Use Project.sourcesRoot instead</ID>
     <ID>ForbiddenComment:SemanticTokens.kt$// TODO: Ideally we would like to cut-off subtrees outside our range, but this doesn't quite seem to work</ID>
     <ID>ForbiddenComment:SourceExclusions.kt$SourceExclusions$// TODO: Read exclusions from gitignore/settings.json/... instead of</ID>
     <ID>ForbiddenComment:SourceFiles.kt$SourceFiles$// TODO: we walk bazel-out here again to collect the files emitted by the aspect</ID>
@@ -211,6 +210,7 @@
     <ID>WildcardImport:Compiler.kt$import org.jetbrains.kotlin.descriptors.*</ID>
     <ID>WildcardImport:Compiler.kt$import org.jetbrains.kotlin.psi.*</ID>
     <ID>WildcardImport:Compiler.kt$import org.jetbrains.kotlin.resolve.*</ID>
+    <ID>WildcardImport:CompilerClassPath.kt$import java.nio.file.*</ID>
     <ID>WildcardImport:Completions.kt$import org.jetbrains.kotlin.descriptors.*</ID>
     <ID>WildcardImport:Completions.kt$import org.jetbrains.kotlin.psi.*</ID>
     <ID>WildcardImport:Completions.kt$import org.jetbrains.kotlin.psi.psiUtil.*</ID>

--- a/server/src/main/kotlin/org/javacs/kt/SourceFiles.kt
+++ b/server/src/main/kotlin/org/javacs/kt/SourceFiles.kt
@@ -195,6 +195,10 @@ class SourceFiles(
                 .map { it.sourceFilesList }
                 .collect(Collectors.toList())
                 .flatten()
+                // we want to use only Kt source files for compiling here
+                // java source files are passed separately. If we pass Java source files directly,
+                // we run into an obscure "Unable to find script compilation configuration for the script KtFile" error
+                .filter { it.path.endsWith(".kt") }
                 .map { Paths.get(it.path).toUri() }
                 .toSet()
         }


### PR DESCRIPTION
Right now, Java source files are passed to compiler directly and expected as `KtFile` which is obviously wrong and leads to

```
Unable to find script compilation configuration for the script KtFile
```

This fixes the code to pass java source files correctly to the compiler.

Tested: locally with a Java/Kotlin bazel target