### PR TITLE
Handle very large classpath

### DIFF
--- a/adapter/src/main/kotlin/org/javacs/ktda/jdi/launch/JDILauncher.kt
+++ b/adapter/src/main/kotlin/org/javacs/ktda/jdi/launch/JDILauncher.kt
@@ -83,7 +83,7 @@ class JDILauncher(
 	private fun formatOptions(config: LaunchConfiguration): String {
 		var options = config.vmArguments
 		modulePaths?.let { options += " --module-path \"$modulePaths\"" }
-		options += " -classpath \"${formatClasspath(config)}\""
+		options += " -classpath @${formatClasspathToFile(config)}"
 		return options
 	}
 
@@ -110,9 +110,16 @@ class JDILauncher(
         }
     }
 
-	private fun formatClasspath(config: LaunchConfiguration): String = config.classpath
-		.map { it.toAbsolutePath().toString() }
-		.reduce { prev, next -> "$prev${File.pathSeparatorChar}$next" }
+	private fun formatClasspathToFile(config: LaunchConfiguration): Path {
+        val tempClassPathFile = File.createTempFile("klsclasspath-", ".txt")
+        val formattedClassPath = formatClasspath(config)
+        tempClassPathFile.writeText(formattedClassPath)
+        return tempClassPathFile.toPath()
+    }
+
+    private fun formatClasspath(config: LaunchConfiguration): String = config.classpath
+        .map { it.toAbsolutePath().toString() }
+        .reduce { prev, next -> "$prev${File.pathSeparatorChar}$next" }
 
 	private fun urlEncode(arg: Collection<String>?) = arg
 		?.map { URLEncoder.encode(it, StandardCharsets.UTF_8.name()) }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=1.3.17-bazel
+version=1.3.18-bazel
 javaVersion=11


### PR DESCRIPTION
When the classpath is too long, it leads to `Argument list too long`. Use an argument file to handle it