### PR TITLE
Use target classpath resolver in debug adapter

### DIFF
--- a/adapter/src/main/kotlin/org/javacs/ktda/adapter/KotlinDebugAdapter.kt
+++ b/adapter/src/main/kotlin/org/javacs/ktda/adapter/KotlinDebugAdapter.kt
@@ -13,6 +13,7 @@ import org.javacs.kt.LogLevel
 import org.javacs.kt.LogMessage
 import org.javacs.kt.util.AsyncExecutor
 import org.javacs.ktda.builder.BuildService
+import org.javacs.ktda.classpath.TargetClassPathResolver
 import org.javacs.ktda.util.JSON_LOG
 import org.javacs.ktda.util.KotlinDAException
 import org.javacs.ktda.util.ObjectPool
@@ -106,9 +107,10 @@ class KotlinDebugAdapter(
 		setupCommonInitializationParams(args)
 
         val classpathResolver = debugClassPathResolver(listOf(workspaceRoot))
+        val targetClassPathResolver = TargetClassPathResolver(workspaceRoot, bazelTarget, buildFlags.filterIsInstance<String>(), builder)
 
 		val config = LaunchConfiguration(
-			classpathResolver.classpathOrEmpty.map { it.compiledJar }.toSet(),
+			targetClassPathResolver.classpath,
 			mainClass,
             bazelTarget,
             classpathResolver.sourceJvmClassNamesOrEmpty,

--- a/adapter/src/main/kotlin/org/javacs/ktda/builder/BazelBuildService.kt
+++ b/adapter/src/main/kotlin/org/javacs/ktda/builder/BazelBuildService.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.withContext
 import org.javacs.kt.LOG
 import org.javacs.ktda.util.KotlinDAException
 import java.io.BufferedReader
+import java.io.File
 import java.io.InputStream
 import java.io.InputStreamReader
 import java.nio.file.Path
@@ -65,22 +66,35 @@ class BazelBuildService: BuildService {
 
     override fun classpath(workspaceRoot: Path, target: String, buildFlags: List<String>): Set<Path> {
         LOG.info("Determining bazel classpath for ${target}")
-        val command = listOf("bazel", "cquery", target) + buildFlags + listOf("--output=starlark", "--starlark:expr='\n'.join([j.path for j in providers(target)['@@_builtins//:common/java/java_info.bzl%JavaInfo'].transitive_runtime_jars.to_list()])")
-        val process = ProcessBuilder().command(command)
+        val starlarkFile = File.createTempFile("bazel-expr", ".star")
+        starlarkFile.writeText("""
+def format(target):
+    return "\n".join([j.path for j in providers(target)["@@_builtins//:common/java/java_info.bzl%JavaInfo"].transitive_runtime_jars.to_list()])
+""")
+        try {
+            val command = listOf("bazel", "cquery", target) + buildFlags + listOf(
+                "--output=starlark",
+                "--starlark:file=${starlarkFile.absolutePath}",
+            )
+            val process = ProcessBuilder().command(command)
                 .directory(workspaceRoot.toFile())
                 .start()
 
-        val returnCode = process.waitFor()
-        val classpathEntries = mutableSetOf<Path>()
-        if(returnCode == 0) {
+            val returnCode = process.waitFor()
+            val classpathEntries = mutableSetOf<Path>()
+            if (returnCode == 0) {
                 process.inputStream.bufferedReader(Charsets.UTF_8).use {
                     it.lines().forEach { line ->
                         classpathEntries.add(workspaceRoot.resolve(line))
                     }
                 }
-        } else {
-                throw KotlinDAException("Unable to determine runtime classpath: bazel cquery failed with exit code $returnCode")
+            } else {
+                val error = process.errorStream.bufferedReader().readText()
+                throw KotlinDAException("Unable to determine runtime classpath: bazel cquery failed with exit code $returnCode, error: $error")
+            }
+            return classpathEntries
+        } finally {
+            starlarkFile.delete()
         }
-        return classpathEntries
     }
 }

--- a/adapter/src/main/kotlin/org/javacs/ktda/builder/BuildService.kt
+++ b/adapter/src/main/kotlin/org/javacs/ktda/builder/BuildService.kt
@@ -5,4 +5,5 @@ import java.util.concurrent.CompletableFuture
 
 interface BuildService {
     fun build(workspaceRoot: Path, targets: List<String>, args: List<String>): CompletableFuture<Void>
+    fun classpath(workspaceRoot: Path, target: String, args: List<String>): Set<Path>
 }

--- a/adapter/src/main/kotlin/org/javacs/ktda/classpath/PathUtils.kt
+++ b/adapter/src/main/kotlin/org/javacs/ktda/classpath/PathUtils.kt
@@ -17,7 +17,8 @@ fun toJVMClassNames(workspaceRoot: Path, filePath: String, sourcesJVMClassNames:
         it.jvmNames
     }.flatten()
     if(jvmNames.isEmpty()) {
-        LOG.warn("Source JVM mappings is empty, breakpoints may not work")
+        LOG.info("Sources are {}", sourcesJVMClassNames)
+        LOG.warn("Source JVM mappings is empty for ${filePath}, breakpoints may not work")
     }
     return jvmNames
 }

--- a/adapter/src/main/kotlin/org/javacs/ktda/classpath/TargetClassPathResolver.kt
+++ b/adapter/src/main/kotlin/org/javacs/ktda/classpath/TargetClassPathResolver.kt
@@ -1,0 +1,13 @@
+package org.javacs.ktda.classpath
+
+import org.javacs.ktda.builder.BuildService
+import java.nio.file.Path
+
+/**
+ * TargetClassPathResolver provides the runtime classpath for a bazel
+ * binary target (java_binary, kt_jvm_target). This is different from the classpath retrieved by the LSP
+ * because it's a global classpath across the workspace which causes runtime issues if there's conflicting jars
+ */
+class TargetClassPathResolver(private val workspceRoot: Path, private val bazelTarget: String, private val bazelArgs: List<String>, private val bazelService: BuildService) {
+    val classpath: Set<Path> get() = bazelService.classpath(workspceRoot, bazelTarget, bazelArgs)
+}

--- a/adapter/src/main/kotlin/org/javacs/ktda/jdi/JDIDebuggee.kt
+++ b/adapter/src/main/kotlin/org/javacs/ktda/jdi/JDIDebuggee.kt
@@ -61,7 +61,7 @@ class JDIDebuggee(
 		LOG.trace("Updating breakpoints")
 		hookBreakpoints()
 
-        LOG.info("Source files are {}", sourceFiles)
+        LOG.debug("Source files are {}", sourceFiles)
 
         // Now that breakpoints are wired, resume the VM
         vm.resume()

--- a/adapter/src/test/kotlin/org/javacs/ktda/DebugAdapterTestFixture.kt
+++ b/adapter/src/test/kotlin/org/javacs/ktda/DebugAdapterTestFixture.kt
@@ -26,6 +26,10 @@ abstract class DebugAdapterTestFixture(
         override fun build(workspaceRoot: Path, targets: List<String>, args: List<String>): CompletableFuture<Void> {
             return CompletableFuture.completedFuture(null)
         }
+
+        override fun classpath(workspaceRoot: Path, target: String, args: List<String>): Set<Path> {
+            return setOf(Paths.get("bazel-out/platform-fastbuild/bin/src/lib.jar"))
+        }
     }
 
     @Before fun startDebugAdapter() {

--- a/adapter/src/test/kotlin/org/javacs/ktda/DebugAdapterTestFixture.kt
+++ b/adapter/src/test/kotlin/org/javacs/ktda/DebugAdapterTestFixture.kt
@@ -28,7 +28,8 @@ abstract class DebugAdapterTestFixture(
         }
 
         override fun classpath(workspaceRoot: Path, target: String, args: List<String>): Set<Path> {
-            return setOf(Paths.get("bazel-out/platform-fastbuild/bin/src/lib.jar"))
+            return setOf(workspaceRoot.resolve("bazel-out/platform-fastbuild/bin/src/lib.jar"),
+                workspaceRoot.resolve("bazel-out/platform-opt-exec/bin/external/maven/org/jetbrains/kotlin/kotlin-stdlib/1.9.21/kotlin-stdlib-1.9.21.jar"),)
         }
     }
 

--- a/detekt_baseline.xml
+++ b/detekt_baseline.xml
@@ -104,6 +104,7 @@
     <ID>MatchingDeclarationName:Main.kt$Args</ID>
     <ID>MayBeConst:LoggingInputStream.kt$private val MESSAGE_FLUSH_MIN_LENGTH = 20</ID>
     <ID>MayBeConst:LoggingOutputStream.kt$private val MESSAGE_FLUSH_MIN_LENGTH = 20</ID>
+    <ID>NestedBlockDepth:BazelBuildService.kt$BazelBuildService$override fun classpath(workspaceRoot: Path, target: String, buildFlags: List&lt;String&gt;): Set&lt;Path&gt;</ID>
     <ID>NestedBlockDepth:Completions.kt$private fun completeMembers(file: CompiledFile, cursor: Int, receiverExpr: KtExpression, unwrapNullable: Boolean = false): Sequence&lt;DeclarationDescriptor&gt;</ID>
     <ID>NestedBlockDepth:KotlinWorkspaceService.kt$KotlinWorkspaceService$override fun didChangeWatchedFiles(params: DidChangeWatchedFilesParams)</ID>
     <ID>NestedBlockDepth:OverrideMembers.kt$private fun parametersMatch( function: KtNamedFunction, functionDescriptor: FunctionDescriptor ): Boolean</ID>


### PR DESCRIPTION
Using a global classpath by walking bazel-out is ok for the LSP but not with the debugger since runtime class conflicts are an issue. So use a target classpath by getting with `bazel cquery` just on that target and passing that to the debugger. we still need the existing resolver to get the source JVM class mappings.