### PR TITLE
Compile files lazily to improve performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ Only VSCode currently is supported/tested, but it may be possible to support oth
 This fork only focuses on Bazel support and making sure it works reliably. As a result
 - I had to remove any existing Gradle/Maven support as supporting all of them at the same time with the other changes was challenging.
 - This does not track all source files in the workspace by default for performance considerations. Only directories which are partially "synced"
- with the vscode extension are tracked and compiled to improve performance.
+ with the vscode extension are tracked and compiled to improve performance. Additionally, there's a "lazy" compilation mode where only files that are open
+ will be compiled and tracked rather than everything in the transitive closure of the packages that are synced.
 - Adapt many of the existing test cases and add a few ones to work with the Bazel implementation.
 - Attempt to compile files in batch rather than do it serially as it was done originally in the LSP presumably because there were errors from the TopDownAnalyzer
 - This has support for Go-to-definition and hover using pure source jars instead of decompiling (which is removed entirely).

--- a/detekt_baseline.xml
+++ b/detekt_baseline.xml
@@ -116,6 +116,7 @@
     <ID>ReturnCount:CompiledFile.kt$CompiledFile$fun referenceAtPoint(cursor: Int): Pair&lt;KtExpression, DeclarationDescriptor&gt;?</ID>
     <ID>ReturnCount:CompiledFile.kt$CompiledFile$fun typeAtPoint(cursor: Int): KotlinType?</ID>
     <ID>ReturnCount:CompiledFile.kt$CompiledFile$private fun getAllSuperclasses(descriptor: DeclarationDescriptor): Set&lt;ClassDescriptor&gt;</ID>
+    <ID>ReturnCount:CompilerClassPath.kt$CompilerClassPath$private fun findJavaSourceFiles(root: Path): Set&lt;Path&gt;</ID>
     <ID>ReturnCount:Completions.kt$private fun completeMembers(file: CompiledFile, cursor: Int, receiverExpr: KtExpression, unwrapNullable: Boolean = false): Sequence&lt;DeclarationDescriptor&gt;</ID>
     <ID>ReturnCount:Completions.kt$private fun findPartialIdentifier(file: CompiledFile, cursor: Int): String</ID>
     <ID>ReturnCount:Completions.kt$private fun implicitMembers(scope: HierarchicalScope): Sequence&lt;DeclarationDescriptor&gt;</ID>

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=1.4.0-bazel
+version=1.5.0-bazel
 javaVersion=11

--- a/server/src/main/kotlin/org/javacs/kt/CompilerClassPath.kt
+++ b/server/src/main/kotlin/org/javacs/kt/CompilerClassPath.kt
@@ -31,7 +31,6 @@ class CompilerClassPath(
     val packageSourceMappings = mutableSetOf<PackageSourceMapping>()
     val outputDirectory: File = Files.createTempDirectory("klsBuildOutput").toFile()
     val javaHome: String? = System.getProperty("java.home", null)
-    private var lazyCompilation: Boolean = false
 
     var compiler = Compiler(
         javaSourcePath,

--- a/server/src/main/kotlin/org/javacs/kt/CompilerClassPath.kt
+++ b/server/src/main/kotlin/org/javacs/kt/CompilerClassPath.kt
@@ -31,6 +31,7 @@ class CompilerClassPath(
     val packageSourceMappings = mutableSetOf<PackageSourceMapping>()
     val outputDirectory: File = Files.createTempDirectory("klsBuildOutput").toFile()
     val javaHome: String? = System.getProperty("java.home", null)
+    private var lazyCompilation: Boolean = false
 
     var compiler = Compiler(
         javaSourcePath,
@@ -171,6 +172,12 @@ class CompilerClassPath(
     private fun isBuildScript(file: Path): Boolean = file.fileName.toString().let { it == "pom.xml" || it == "build.gradle" || it == "build.gradle.kts" }
 
     private fun findJavaSourceFiles(root: Path): Set<Path> {
+        // If using lazy compilation, don't track the files in the transitive closure
+        // unless they're opened
+        if(config.lazyCompilation) {
+            return emptySet()
+        }
+
         val bazelOut = root.resolve("bazel-out")
         if(!Files.exists(bazelOut)) {
             return emptySet()

--- a/server/src/main/kotlin/org/javacs/kt/Configuration.kt
+++ b/server/src/main/kotlin/org/javacs/kt/Configuration.kt
@@ -41,7 +41,9 @@ public data class JVMConfiguration(
 )
 
 public data class CompilerConfiguration(
-    val jvm: JVMConfiguration = JVMConfiguration()
+    val jvm: JVMConfiguration = JVMConfiguration(),
+    // whether to do lazy compilation, on demand whenever files are open-ed/referenced
+    var lazyCompilation: Boolean = true
 )
 
 public data class IndexingConfiguration(

--- a/server/src/main/kotlin/org/javacs/kt/KotlinLanguageServer.kt
+++ b/server/src/main/kotlin/org/javacs/kt/KotlinLanguageServer.kt
@@ -31,7 +31,7 @@ class KotlinLanguageServer(
     private val tempDirectory = TemporaryDirectory()
     private val uriContentProvider = URIContentProvider(ClassContentProvider(config.externalSources, classPath, tempDirectory, CompositeSourceArchiveProvider(JdkSourceArchiveProvider(classPath), ClassPathSourceArchiveProvider(classPath))))
     val sourcePath = SourcePath(classPath, uriContentProvider, config.indexing, databaseService)
-    val sourceFiles = SourceFiles(sourcePath, uriContentProvider, config.scripts)
+    val sourceFiles = SourceFiles(sourcePath, uriContentProvider, config.scripts, config.compiler.lazyCompilation)
 
     private val textDocuments = KotlinTextDocumentService(sourceFiles, sourcePath, config, tempDirectory, uriContentProvider, classPath)
     private val workspaces = KotlinWorkspaceService(sourceFiles, sourcePath, classPath, textDocuments, config)

--- a/server/src/main/kotlin/org/javacs/kt/KotlinWorkspaceService.kt
+++ b/server/src/main/kotlin/org/javacs/kt/KotlinWorkspaceService.kt
@@ -114,6 +114,11 @@ class KotlinWorkspaceService(
                     cp.updateCompilerConfiguration()
                 }
 
+                get("lazyCompilation")?.asBoolean?.let{
+                    config.compiler.lazyCompilation = it
+                    cp.updateCompilerConfiguration()
+                }
+
                 // Update options for formatting
                 get("formatting")?.asJsonObject?.apply {
                     val formatting = config.formatting

--- a/server/src/main/kotlin/org/javacs/kt/SourceFiles.kt
+++ b/server/src/main/kotlin/org/javacs/kt/SourceFiles.kt
@@ -68,7 +68,8 @@ private class NotifySourcePath(private val sp: SourcePath) {
 class SourceFiles(
     private val sp: SourcePath,
     private val contentProvider: URIContentProvider,
-    private val scriptsConfig: ScriptsConfiguration
+    private val scriptsConfig: ScriptsConfiguration,
+    private val lazyCompilation: Boolean,
 ) {
     private val workspaceRoots = mutableSetOf<Path>()
     private var exclusions = SourceExclusions(workspaceRoots, scriptsConfig)
@@ -157,7 +158,13 @@ class SourceFiles(
 
     fun addWorkspaceRoot(root: Path) {
         LOG.info("Searching $root using exclusions: ${exclusions.excludedPatterns}")
-        val addSources = findSourceFiles(root)
+        val addSources = if(lazyCompilation) {
+            LOG.info("Lazy compilation enabled, files will be compiled on-demand.")
+            emptySet()
+        } else {
+            LOG.info("Lazy compilation disabled, all files in the transitive closure will be compiled.")
+            findSourceFiles(root)
+        }
 
         logAdded(addSources, root)
 


### PR DESCRIPTION
Instead of trying to compile every source file in the transitive closure, we should just try to compile files that are open, we already track files that are open in `lintToDo`, and compiling individual files should still work because we have symbols through the classpath entries during the bazel build