### PR TITLE
Handle lazy compilation to support Go-to

### DIFF
--- a/detekt_baseline.xml
+++ b/detekt_baseline.xml
@@ -43,7 +43,6 @@
     <ID>ForbiddenComment:KotlinDebugAdapter.kt$KotlinDebugAdapter$// TODO: This is a workaround for https://github.com/eclipse/lsp4j/issues/229</ID>
     <ID>ForbiddenComment:KotlinDebugAdapter.kt$KotlinDebugAdapter$// TODO: Use actual exitCode instead</ID>
     <ID>ForbiddenComment:KotlinTextDocumentService.kt$KotlinTextDocumentService$// TODO: Investigate when to recompile</ID>
-    <ID>ForbiddenComment:KotlinTextDocumentService.kt$KotlinTextDocumentService$// TODO: comment this in code, we need to use DI and abstract this out</ID>
     <ID>ForbiddenComment:OverrideMembers.kt$// TODO: any way can repeat less code between this and the getAbstractMembersStubs in the ImplementAbstractMembersQuickfix?</ID>
     <ID>ForbiddenComment:OverrideMembers.kt$// TODO: does not seem to handle the implicit Any and Object super types that well. Need to find out if that is easily solvable. Finds the methods from them if any super class or interface is present</ID>
     <ID>ForbiddenComment:OverrideMembers.kt$// TODO: look further into this</ID>
@@ -101,6 +100,7 @@
     <ID>MagicNumber:WithStdlibResolver.kt$StdLibItem.Companion$3</ID>
     <ID>MagicNumber:WithStdlibResolver.kt$StdLibItem.Companion$4</ID>
     <ID>MagicNumber:WithStdlibResolver.kt$StdLibItem.Companion$5</ID>
+    <ID>MatchingDeclarationName:Exceptions.kt$KotlinFilesNotCompiledYetException : Exception</ID>
     <ID>MatchingDeclarationName:Main.kt$Args</ID>
     <ID>MayBeConst:LoggingInputStream.kt$private val MESSAGE_FLUSH_MIN_LENGTH = 20</ID>
     <ID>MayBeConst:LoggingOutputStream.kt$private val MESSAGE_FLUSH_MIN_LENGTH = 20</ID>
@@ -132,6 +132,7 @@
     <ID>ReturnCount:Hovers.kt$fun processSourceJar(mapping: PackageSourceMapping): String?</ID>
     <ID>ReturnCount:Hovers.kt$private fun typeHoverAt(file: CompiledFile, cursor: Int): Hover?</ID>
     <ID>ReturnCount:JDIDebuggee.kt$JDIDebuggee$private fun setBreakpointAtType(refType: ReferenceType, lineNumber: Long): Boolean</ID>
+    <ID>ReturnCount:KotlinTextDocumentService.kt$KotlinTextDocumentService$private inline fun &lt;T&gt; withLazyCompilationRetry( fallback: () -&gt; T, block: () -&gt; T ): T</ID>
     <ID>ReturnCount:OverrideMembers.kt$private fun parametersMatch( function: KtNamedFunction, functionDescriptor: FunctionDescriptor ): Boolean</ID>
     <ID>ReturnCount:Parser.kt$SourceJarParser$fun findSourceFileInfo( sourcesJarPath: String, packageName: String, className: String ): SourceFileInfo?</ID>
     <ID>ReturnCount:Position.kt$fun location(declaration: DeclarationDescriptor): Location?</ID>
@@ -157,6 +158,7 @@
     <ID>TooGenericExceptionCaught:ClassPathResolver.kt$ClassPathResolver$e: Exception</ID>
     <ID>TooGenericExceptionCaught:Compiler.kt$CompilationEnvironment$e: Exception</ID>
     <ID>TooGenericExceptionCaught:Completions.kt$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:KotlinTextDocumentService.kt$KotlinTextDocumentService$ex: Exception</ID>
     <ID>TooGenericExceptionCaught:Position.kt$e: NullPointerException</ID>
     <ID>TooGenericExceptionCaught:SourcePath.kt$SourcePath$ex: Exception</ID>
     <ID>TooGenericExceptionCaught:SymbolIndex.kt$SymbolIndex$e: Exception</ID>
@@ -237,6 +239,7 @@
     <ID>WildcardImport:KotlinProtocolExtensionService.kt$import org.eclipse.lsp4j.*</ID>
     <ID>WildcardImport:KotlinProtocolExtensions.kt$import org.eclipse.lsp4j.*</ID>
     <ID>WildcardImport:KotlinTextDocumentService.kt$import org.eclipse.lsp4j.*</ID>
+    <ID>WildcardImport:KotlinTextDocumentService.kt$import org.javacs.kt.util.*</ID>
     <ID>WildcardImport:KotlinWorkspaceService.kt$import org.eclipse.lsp4j.*</ID>
     <ID>WildcardImport:Rename.kt$import org.eclipse.lsp4j.*</ID>
     <ID>WildcardImport:RenderCompletionItem.kt$import org.jetbrains.kotlin.descriptors.*</ID>

--- a/server/src/main/kotlin/org/javacs/kt/CompiledFile.kt
+++ b/server/src/main/kotlin/org/javacs/kt/CompiledFile.kt
@@ -34,6 +34,7 @@ import org.jetbrains.kotlin.psi.psiUtil.findDescendantOfType
 import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameSafe
 import java.nio.file.Path
 import java.nio.file.Paths
+import kotlin.io.path.absolutePathString
 
 class CompiledFile(
     val content: String,
@@ -97,6 +98,7 @@ class CompiledFile(
      */
     fun referenceExpressionAtPoint(cursor: Int): Pair<KtExpression, DeclarationDescriptor>? {
         val path = parse.containingFile.toPath()
+        LOG.info("Path: {}", path.absolutePathString())
         return referenceFromContext(cursor, path, compile)
     }
 

--- a/server/src/main/kotlin/org/javacs/kt/CompilerClassPath.kt
+++ b/server/src/main/kotlin/org/javacs/kt/CompilerClassPath.kt
@@ -2,6 +2,7 @@ package org.javacs.kt
 
 import org.javacs.kt.classpath.ClassPathEntry
 import org.javacs.kt.classpath.PackageSourceMapping
+import org.javacs.kt.classpath.SourceJVMClassNames
 import org.javacs.kt.classpath.defaultClassPathResolver
 import org.javacs.kt.compiler.Compiler
 import org.javacs.kt.database.DatabaseService
@@ -29,6 +30,7 @@ class CompilerClassPath(
     private val buildScriptClassPath = mutableSetOf<Path>()
     val classPath = mutableSetOf<ClassPathEntry>()
     val packageSourceMappings = mutableSetOf<PackageSourceMapping>()
+    val sourcesJvmClassNames = mutableSetOf<SourceJVMClassNames>()
     val outputDirectory: File = Files.createTempDirectory("klsBuildOutput").toFile()
     val javaHome: String? = System.getProperty("java.home", null)
 
@@ -71,6 +73,13 @@ class CompilerClassPath(
             if(newPackageSourceMappings != packageSourceMappings) {
                 synchronized(packageSourceMappings) {
                     syncPaths(packageSourceMappings,newPackageSourceMappings,"package source mappings") { it.sourceJar }
+                }
+            }
+
+            val newSourceJVMClassNames = resolver.sourceJvmClassNames
+            if(newSourceJVMClassNames != sourcesJvmClassNames) {
+                synchronized(sourcesJvmClassNames) {
+                    syncPaths(sourcesJvmClassNames, newSourceJVMClassNames, "source jvm classes") {it.sourceFile}
                 }
             }
 

--- a/server/src/main/kotlin/org/javacs/kt/KotlinTextDocumentService.kt
+++ b/server/src/main/kotlin/org/javacs/kt/KotlinTextDocumentService.kt
@@ -187,15 +187,6 @@ class KotlinTextDocumentService(
         LOG.info { "Linting $uri" }
         sf.open(uri, params.textDocument.text, params.textDocument.version)
         lintNow(uri)
-
-        // TODO: comment this in code, we need to use DI and abstract this out
-        // for tests to pass
-        // notify client that linting or compiling was done
-//        val documentNotification = mapOf("uri" to uri, "kind" to "end")
-//        val params = ProgressParams()
-//        params.token = Either.forLeft("bazelKLS/kotlinAnalysis")
-//        params.value = Either.forRight(documentNotification)
-//        client.notifyProgress(params)
     }
 
     override fun didSave(params: DidSaveTextDocumentParams) {

--- a/server/src/main/kotlin/org/javacs/kt/KotlinTextDocumentService.kt
+++ b/server/src/main/kotlin/org/javacs/kt/KotlinTextDocumentService.kt
@@ -25,7 +25,6 @@ import org.jetbrains.kotlin.resolve.diagnostics.Diagnostics
 import java.net.URI
 import java.io.Closeable
 import java.nio.file.Path
-import java.nio.file.Paths
 import java.time.Duration
 import java.util.concurrent.CompletableFuture
 

--- a/server/src/main/kotlin/org/javacs/kt/KotlinTextDocumentService.kt
+++ b/server/src/main/kotlin/org/javacs/kt/KotlinTextDocumentService.kt
@@ -140,6 +140,7 @@ class KotlinTextDocumentService(
             return block()
         } catch (e: KotlinFilesNotCompiledYetException) {
             val files = e.files.map { cp.workspaceRoots.first().resolve(it) }.toSet()
+            if(files.size == 0) return fallback()
             try {
                 LOG.info("Compilation will be done on-demand for ${files.map { it.fileName }}")
                 sp.addPaths(files)

--- a/server/src/main/kotlin/org/javacs/kt/KotlinTextDocumentService.kt
+++ b/server/src/main/kotlin/org/javacs/kt/KotlinTextDocumentService.kt
@@ -130,7 +130,7 @@ class KotlinTextDocumentService(
             LOG.info("Go-to-definition at {}", describePosition(position))
 
             val (file, cursor) = recover(position, Recompile.NEVER) ?: return@compute Either.forLeft(emptyList())
-            goToDefinition(file, cursor, tempDirectory, cp)
+            goToDefinition(file, cursor, tempDirectory, cp, config)
                 ?.let(::listOf)
                 ?.let { Either.forLeft<List<Location>, List<LocationLink>>(it) }
                 ?: noResult("Couldn't find definition at ${describePosition(position)}", Either.forLeft(emptyList()))

--- a/server/src/main/kotlin/org/javacs/kt/KotlinTextDocumentService.kt
+++ b/server/src/main/kotlin/org/javacs/kt/KotlinTextDocumentService.kt
@@ -20,18 +20,12 @@ import org.javacs.kt.rename.renameSymbol
 import org.javacs.kt.highlight.documentHighlightsAt
 import org.javacs.kt.inlayhints.provideHints
 import org.javacs.kt.symbols.documentSymbols
-import org.javacs.kt.util.AsyncExecutor
-import org.javacs.kt.util.Debouncer
-import org.javacs.kt.util.TemporaryDirectory
-import org.javacs.kt.util.describeURI
-import org.javacs.kt.util.describeURIs
-import org.javacs.kt.util.filePath
-import org.javacs.kt.util.noResult
-import org.javacs.kt.util.parseURI
+import org.javacs.kt.util.*
 import org.jetbrains.kotlin.resolve.diagnostics.Diagnostics
 import java.net.URI
 import java.io.Closeable
 import java.nio.file.Path
+import java.nio.file.Paths
 import java.time.Duration
 import java.util.concurrent.CompletableFuture
 
@@ -128,13 +122,45 @@ class KotlinTextDocumentService(
     override fun definition(position: DefinitionParams): CompletableFuture<Either<List<Location>, List<LocationLink>>> = async.compute {
         reportTime {
             LOG.info("Go-to-definition at {}", describePosition(position))
-
-            val (file, cursor) = recover(position, Recompile.NEVER) ?: return@compute Either.forLeft(emptyList())
-            goToDefinition(file, cursor, tempDirectory, cp, config)
-                ?.let(::listOf)
-                ?.let { Either.forLeft<List<Location>, List<LocationLink>>(it) }
-                ?: noResult("Couldn't find definition at ${describePosition(position)}", Either.forLeft(emptyList()))
+            if(config.compiler.lazyCompilation) {
+                return@compute withLazyCompilationRetry(
+                    fallback = { Either.forLeft(emptyList()) },
+                    block = { doDefinition(position) }
+                )
+            }
+            return@compute doDefinition(position)
         }
+    }
+
+    private inline fun <T> withLazyCompilationRetry(
+        fallback: () -> T,
+        block: () -> T
+    ): T {
+        try {
+            return block()
+        } catch (e: KotlinFilesNotCompiledYetException) {
+            val files = e.files.map { cp.workspaceRoots.first().resolve(it) }.toSet()
+            try {
+                LOG.info("Compilation will be done on-demand for ${files.map { it.fileName }}")
+                sp.addPaths(files)
+                sp.compileFiles(files.map { it.toUri() })
+                sp.refresh()
+                sp.refreshDependencyIndexes()
+                return block()
+            } catch (ex: Exception) {
+                LOG.warn("Failed during lazy compilation or second attempt", ex)
+                return fallback()
+            }
+        }
+    }
+
+
+    private fun doDefinition(position: DefinitionParams, recompile: Recompile = Recompile.NEVER): Either<List<Location>, List<LocationLink>> {
+        val (file, cursor) = recover(position, recompile) ?: return Either.forLeft(emptyList())
+        return goToDefinition(file, cursor, tempDirectory, cp, config)
+            ?.let(::listOf)
+            ?.let { Either.forLeft<List<Location>, List<LocationLink>>(it) }
+            ?: noResult("Couldn't find definition at ${describePosition(position)}", Either.forLeft(emptyList()))
     }
 
     override fun rangeFormatting(params: DocumentRangeFormattingParams): CompletableFuture<List<TextEdit>> = async.compute {

--- a/server/src/main/kotlin/org/javacs/kt/SourcePath.kt
+++ b/server/src/main/kotlin/org/javacs/kt/SourcePath.kt
@@ -19,6 +19,7 @@ import java.nio.file.Path
 import java.nio.file.Paths
 import java.net.URI
 import java.util.concurrent.locks.ReentrantLock
+import kotlin.io.path.readText
 
 class SourcePath(
     private val cp: CompilerClassPath,
@@ -351,6 +352,13 @@ class SourcePath(
             LOG.info("Refreshing source path")
             files.values.forEach { it.clean() }
             files.values.forEach { it.compile() }
+        }
+    }
+
+    fun addPaths(paths: Set<Path>) {
+        paths.forEach {
+            put(it.toUri(), it.readText(), null, false)
+            save(it.toUri())
         }
     }
 

--- a/server/src/main/kotlin/org/javacs/kt/definition/GoToDefinition.kt
+++ b/server/src/main/kotlin/org/javacs/kt/definition/GoToDefinition.kt
@@ -44,8 +44,15 @@ fun goToDefinition(
             destination = psi.nameIdentifier?.let(::location) ?: destination
         }
         if(destination == null && configuration.compiler.lazyCompilation) {
-            val jvmName = target.fqNameSafe.asString()
-            val possibleSourceFiles = cp.sourcesJvmClassNames.filter { it.jvmNames.contains(jvmName) }.map { it.sourceFile }
+            // This might only work for classes for now
+            val jvmName = if(target is FunctionDescriptor) {
+                target.containingDeclaration.fqNameSafe.asString()
+            } else {
+                target.fqNameSafe.asString()
+            }
+            val possibleSourceFiles = cp.sourcesJvmClassNames.filter { it.jvmNames.contains(jvmName) || it.jvmNames.any { name ->
+                name.contains(jvmName)
+            }}.map { it.sourceFile }
             throw KotlinFilesNotCompiledYetException(possibleSourceFiles.toSet(), "Didn't find PSI location because files ${possibleSourceFiles.joinToString(",")} may not not compiled yet")
         }
     }

--- a/server/src/main/kotlin/org/javacs/kt/definition/GoToDefinition.kt
+++ b/server/src/main/kotlin/org/javacs/kt/definition/GoToDefinition.kt
@@ -44,7 +44,7 @@ fun goToDefinition(
             destination = psi.nameIdentifier?.let(::location) ?: destination
         }
         if(destination == null && configuration.compiler.lazyCompilation) {
-            // This might only work for classes for now
+            // This might only work for classes and functions for now
             val jvmName = if(target is FunctionDescriptor) {
                 target.containingDeclaration.fqNameSafe.asString()
             } else {

--- a/server/src/main/kotlin/org/javacs/kt/position/Position.kt
+++ b/server/src/main/kotlin/org/javacs/kt/position/Position.kt
@@ -94,9 +94,11 @@ fun location(declaration: DeclarationDescriptor): Location? {
 
     if (declaration is DeclarationDescriptorWithSource) {
         val sourceFile = declaration.source.containingFile
+        LOG.info("Source file is ${sourceFile}")
         when (sourceFile) {
             is PsiSourceFile -> {
                 val file = sourceFile.psiFile.toURIString()
+                LOG.info("Source path is ${file}")
                 return Location(file, Range(Position(0, 0), Position(0, 0)))
             }
             SourceFile.NO_SOURCE_FILE -> Unit // If no source file is present, do nothing

--- a/server/src/main/kotlin/org/javacs/kt/util/Exceptions.kt
+++ b/server/src/main/kotlin/org/javacs/kt/util/Exceptions.kt
@@ -1,0 +1,5 @@
+package org.javacs.kt.util
+
+import java.nio.file.Path
+
+class KotlinFileNotCompiledYetException(val filePath: Path, message: String): Exception(message)

--- a/server/src/main/kotlin/org/javacs/kt/util/Exceptions.kt
+++ b/server/src/main/kotlin/org/javacs/kt/util/Exceptions.kt
@@ -2,4 +2,4 @@ package org.javacs.kt.util
 
 import java.nio.file.Path
 
-class KotlinFileNotCompiledYetException(val filePath: Path, message: String): Exception(message)
+class KotlinFilesNotCompiledYetException(val files: Set<Path>, message: String): Exception(message)

--- a/shared/src/main/kotlin/org/javacs/kt/classpath/CachedClassPathResolver.kt
+++ b/shared/src/main/kotlin/org/javacs/kt/classpath/CachedClassPathResolver.kt
@@ -44,7 +44,7 @@ class PackageSourceMappingEntryEntity(id: EntityID<Int>) : IntEntity(id) {
 
 private object SourceJVMClassNamesEntry : IntIdTable() {
     val sourceFile = varchar("sourcefile", length = MAX_PATH_LENGTH)
-    val jvmClassNames = varchar("jvmclassnames", length = MAX_PATH_LENGTH).nullable()
+    val jvmClassNames = text("jvmclassnames").nullable()
 }
 
 class SourceJVMClassNamesEntryEntity(id: EntityID<Int>) : IntEntity(id) {
@@ -166,7 +166,7 @@ internal class CachedClassPathResolver(
     init {
         transaction(db) {
             SchemaUtils.createMissingTablesAndColumns(
-                ClassPathMetadataCache, ClassPathCacheEntry, BuildScriptClassPathCacheEntry, PackageSourceJarMappingEntry
+                ClassPathMetadataCache, ClassPathCacheEntry, BuildScriptClassPathCacheEntry, PackageSourceJarMappingEntry, SourceJVMClassNamesEntry
             )
         }
     }

--- a/shared/src/main/kotlin/org/javacs/kt/database/DatabaseService.kt
+++ b/shared/src/main/kotlin/org/javacs/kt/database/DatabaseService.kt
@@ -26,7 +26,7 @@ class DatabaseMetadataEntity(id: EntityID<Int>) : IntEntity(id) {
 class DatabaseService {
 
     companion object {
-        const val DB_VERSION = 14
+        const val DB_VERSION = 15
         const val DB_FILENAME = "kls_database.db"
     }
 


### PR DESCRIPTION
Compile on demand whenever we want to `Go-to` on a symbol on a file that's not yet compiled. To find the files we need to compile, we extract the JVM name and try to map it back to the source files.

Then, recompile the files, refresh the indices and retry goto