### PR TITLE
Disable lazy compilation by default

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=1.5.0-bazel
+version=1.5.1-bazel
 javaVersion=11

--- a/server/src/main/kotlin/org/javacs/kt/Configuration.kt
+++ b/server/src/main/kotlin/org/javacs/kt/Configuration.kt
@@ -43,7 +43,7 @@ public data class JVMConfiguration(
 public data class CompilerConfiguration(
     val jvm: JVMConfiguration = JVMConfiguration(),
     // whether to do lazy compilation, on demand whenever files are open-ed/referenced
-    var lazyCompilation: Boolean = true
+    var lazyCompilation: Boolean = false
 )
 
 public data class IndexingConfiguration(


### PR DESCRIPTION
This was enabled by default in the LSP, so not in tandem with the extension