### PR TITLE
Initialize lazy compilation config on startup

### DIFF
--- a/detekt_baseline.xml
+++ b/detekt_baseline.xml
@@ -59,6 +59,7 @@
     <ID>ForbiddenComment:VariableTreeNode.kt$VariableTreeNode$// TODO: Setters for values?</ID>
     <ID>FunctionOnlyReturningConstant:Example.kt$fun example()</ID>
     <ID>LongMethod:Compiler.kt$CompilationEnvironment.&lt;no name provided&gt;.&lt;no name provided&gt;$override fun resolve(scriptContents: ScriptContents, environment: Environment)</ID>
+    <ID>LongMethod:KotlinLanguageServer.kt$KotlinLanguageServer$override fun initialize(params: InitializeParams): CompletableFuture&lt;InitializeResult&gt;</ID>
     <ID>LongMethod:SemanticTokens.kt$private fun elementToken(element: PsiElement, bindingContext: BindingContext): SemanticToken?</ID>
     <ID>LongParameterList:CompiledFile.kt$CompiledFile$( val content: String, val parse: KtFile, val compile: BindingContext, val module: ModuleDescriptor, val sourcePath: Collection&lt;KtFile&gt;, val classPath: CompilerClassPath, val isScript: Boolean = false, val isTestFile: Boolean = false, val kind: CompilationKind = CompilationKind.DEFAULT )</ID>
     <ID>LongParameterList:GoToDefinition.kt$( workspaceRoot: Path, sourceJar: String, packageName: String, className: String, symbolName: String, compiler: Compiler, tempDir: TemporaryDirectory )</ID>
@@ -235,7 +236,6 @@
     <ID>WildcardImport:JavaTypeConverter.kt$import com.intellij.psi.*</ID>
     <ID>WildcardImport:KotlinDebugAdapter.kt$import org.eclipse.lsp4j.debug.*</ID>
     <ID>WildcardImport:KotlinLanguageServer.kt$import org.eclipse.lsp4j.*</ID>
-    <ID>WildcardImport:KotlinLanguageServer.kt$import org.javacs.kt.externalsources.*</ID>
     <ID>WildcardImport:KotlinProtocolExtensionService.kt$import org.eclipse.lsp4j.*</ID>
     <ID>WildcardImport:KotlinProtocolExtensions.kt$import org.eclipse.lsp4j.*</ID>
     <ID>WildcardImport:KotlinTextDocumentService.kt$import org.eclipse.lsp4j.*</ID>

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=1.5.1-bazel
+version=1.5.2-bazel
 javaVersion=11

--- a/server/src/main/kotlin/org/javacs/kt/Configuration.kt
+++ b/server/src/main/kotlin/org/javacs/kt/Configuration.kt
@@ -77,12 +77,12 @@ data class FormattingConfiguration(
     var ktfmt: KtfmtConfiguration = KtfmtConfiguration()
 )
 
-fun getStoragePath(params: InitializeParams): Path? {
+fun getInitializationOptions(params: InitializeParams): InitializationOptions? {
     params.initializationOptions?.let { initializationOptions ->
         val gson = GsonBuilder().registerTypeHierarchyAdapter(Path::class.java, GsonPathConverter()).create()
         val options = gson.fromJson(initializationOptions as JsonElement, InitializationOptions::class.java)
 
-        return options?.storagePath
+        return options
     }
 
     return null
@@ -90,7 +90,9 @@ fun getStoragePath(params: InitializeParams): Path? {
 
 data class InitializationOptions(
     // A path to a directory used by the language server to store data. Used for caching purposes.
-    val storagePath: Path?
+    val storagePath: Path?,
+    // If lazy compilation is to be enabled by the language server. Used for performance improvements
+    val lazyCompilation: Boolean = false,
 )
 
 class GsonPathConverter : JsonDeserializer<Path?> {


### PR DESCRIPTION
Without this, it always starts up with lazy compilation disabled which is not ideal, so it should honor the config from client