### PR TITLE
Pick atleast one file for symbol indexing

### DIFF
--- a/server/src/main/kotlin/org/javacs/kt/SourceFiles.kt
+++ b/server/src/main/kotlin/org/javacs/kt/SourceFiles.kt
@@ -159,12 +159,14 @@ class SourceFiles(
 
     fun addWorkspaceRoot(root: Path) {
         LOG.info("Searching $root using exclusions: ${exclusions.excludedPatterns}")
-        val addSources = if(lazyCompilation) {
+        val allSourceFiles = findSourceFiles(root)
+        val addSources = if (lazyCompilation) {
+            // We need atleast once source to compile, get a moduledescriptor and all the dependencies for symbol indexing
             LOG.info("Lazy compilation enabled, files will be compiled on-demand.")
-            open
+            allSourceFiles.takeIf { it.isNotEmpty() }?.take(1) ?: emptySet()
         } else {
             LOG.info("Lazy compilation disabled, all files in the transitive closure will be compiled.")
-            findSourceFiles(root)
+            allSourceFiles
         }
 
         logAdded(addSources, root)


### PR DESCRIPTION
When lazy compilation is enabled, we pick no files unless a file is opened and there might be a race condition which might result in symbols not being indexed.

To avoid that, we can always pick one and any file and get the module dependencies for it to complete the full bazel symbol indexing.