### PR TITLE
Fix query for global symbols and do indexing in background

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=1.6.0-bazel
+version=1.6.1-bazel
 javaVersion=11

--- a/server/src/main/kotlin/org/javacs/kt/SourcePath.kt
+++ b/server/src/main/kotlin/org/javacs/kt/SourcePath.kt
@@ -324,9 +324,9 @@ class SourcePath(
     /**
      * Triggers a full refresh of the Bazel symbol, all top-level declarations are extracted and stored in the symbol index
      */
-    private fun refreshBazelIndexes(module: ModuleDescriptor) {
+    private fun refreshBazelIndexes(module: ModuleDescriptor) = indexAsync.execute {
         if (indexEnabled) {
-            LOG.info("Refreshing full bazel symbol view...")
+            LOG.info("Refreshing full bazel symbol index in background...")
             val bazelSymbolView = BazelSymbolView(module, cp.packageSourceMappings)
             val declarations = bazelSymbolView.getAllTopLevelDeclarations()
             index.refresh(declarations)

--- a/server/src/main/kotlin/org/javacs/kt/index/SymbolIndex.kt
+++ b/server/src/main/kotlin/org/javacs/kt/index/SymbolIndex.kt
@@ -99,9 +99,9 @@ class SymbolIndex(
     /** Rebuilds the entire index. May take a while. */
     fun refresh(descriptors: Sequence<DeclarationDescriptor>) {
         val started = System.currentTimeMillis()
-        LOG.info("Updating full bazel symbol index...")
+        LOG.info("Updating full bazel symbol index, this is required for most global completions/quick fixes to work...")
 
-        progressFactory.create("Indexing symbols").thenApply { progress ->
+        progressFactory.create("Indexing bazel symbols").thenApply { progress ->
             try {
                 transaction(db) {
                     // Keeping track of progress


### PR DESCRIPTION
The `distinctBy` seems to remove a bunch of symbols from suggestions even though they come from different packages, so keep it.

Also do the indexing in background, I switched it to sync but it doesn't really make sense to block the LSP and user while this is going on even if they don't get all the suggestions they need.

