### PR TITLE
Set JVM target for compiler to Java 17 as default

### DIFF
--- a/server/src/main/kotlin/org/javacs/kt/Configuration.kt
+++ b/server/src/main/kotlin/org/javacs/kt/Configuration.kt
@@ -37,7 +37,7 @@ public data class DiagnosticsConfiguration(
 
 public data class JVMConfiguration(
     /** Which JVM target the Kotlin compiler uses. See Compiler.jvmTargetFrom for possible values. */
-    var target: String = "11"
+    var target: String = "17"
 )
 
 public data class CompilerConfiguration(
@@ -93,6 +93,8 @@ data class InitializationOptions(
     val storagePath: Path?,
     // If lazy compilation is to be enabled by the language server. Used for performance improvements
     val lazyCompilation: Boolean = false,
+    // The JVM configuration, which encapsulates the Java version used by the Kotlin compiler
+    val jvmConfiguration: JVMConfiguration? = JVMConfiguration(),
 )
 
 class GsonPathConverter : JsonDeserializer<Path?> {

--- a/server/src/main/kotlin/org/javacs/kt/KotlinLanguageServer.kt
+++ b/server/src/main/kotlin/org/javacs/kt/KotlinLanguageServer.kt
@@ -103,6 +103,9 @@ class KotlinLanguageServer(
             LOG.info("Lazy compilation - ${it.lazyCompilation}")
             config.compiler.lazyCompilation = it.lazyCompilation
             sourceFiles.lazyCompilation = it.lazyCompilation
+            it.jvmConfiguration?.let { jvmConfig ->
+                config.compiler.jvm.target = jvmConfig.target
+            }
         }
 
 

--- a/server/src/main/kotlin/org/javacs/kt/KotlinLanguageServer.kt
+++ b/server/src/main/kotlin/org/javacs/kt/KotlinLanguageServer.kt
@@ -104,6 +104,7 @@ class KotlinLanguageServer(
             config.compiler.lazyCompilation = it.lazyCompilation
             sourceFiles.lazyCompilation = it.lazyCompilation
             it.jvmConfiguration?.let { jvmConfig ->
+                LOG.info("JVM Target - ${jvmConfig.target}")
                 config.compiler.jvm.target = jvmConfig.target
             }
         }


### PR DESCRIPTION
Java 11 OSS is EoL, so switch to Java 17 target as default for the compiler. The extension will also be updated. Users can override the config on the client to force Java 11 (or 21) if needed.